### PR TITLE
Make serde optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ readme = "README.md"
 keywords = ["nlp", "stemming", "information", "retrieval", "language"]
 license = "MIT/BSD-3-Clause"
 
+[features]
+default = ["serde"]
+serde = ["dep:serde", "dep:serde_derive"]
+
 [dependencies]
-serde = "^1.0"
-serde_derive = "^1.0"
+serde = { version = "^1.0", optional = true }
+serde_derive = { version = "^1.0", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,10 @@
 //!    assert_eq!(en_stemmer.stem("fruitlessly"), "fruitless");
 //! }
 //! ```
+#[cfg(feature="serde")]
 extern crate serde;
+
+#[cfg(feature="serde")]
 #[macro_use]
 extern crate serde_derive;
 
@@ -33,7 +36,8 @@ use snowball::algorithms;
 
 /// Enum of all supported algorithms.
 /// Check the [Snowball-Website](https://snowballstem.org/) for details.
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Copy, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum Algorithm {
     Arabic,
     Armenian,
@@ -320,6 +324,27 @@ mod tests {
                       res.unwrap().as_str(),
                       Algorithm::Norwegian);
         }
+    }
+
+    #[cfg(feature = "serde")]
+    fn dummy_serialization_function<T: serde::Serialize>(x: T) {
+        drop(x)
+    }
+
+    #[cfg(feature = "serde")]
+    fn dummy_deserialization_function<T: serde::de::DeserializeOwned>(x: T) {
+        drop(x)
+    }
+
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn serialization() {
+        let algorithm = Algorithm::English;
+        dummy_deserialization_function(algorithm);
+
+        let algorithm2 = Algorithm::Spanish;
+        dummy_serialization_function(algorithm2);
     }
 
 }

--- a/src/snowball/algorithms/armenian.rs
+++ b/src/snowball/algorithms/armenian.rs
@@ -219,8 +219,8 @@ struct Context {
 }
 
 fn r_mark_regions(env: &mut SnowballEnv, context: &mut Context) -> bool {
-    context.i_pV = env.limit;
-    context.i_p2 = env.limit;
+    context.i_pV = env.limit as i32;
+    context.i_p2 = env.limit as i32;
     let v_1 = env.cursor;
     'lab0: loop {
         'golab1: loop {
@@ -235,7 +235,7 @@ fn r_mark_regions(env: &mut SnowballEnv, context: &mut Context) -> bool {
             }
             env.next_char();
         }
-        context.i_pV = env.cursor;
+        context.i_pV = env.cursor as i32;
         'golab3: loop {
             'lab4: loop {
                 if !env.out_grouping(G_v, 1377, 1413) {
@@ -272,7 +272,7 @@ fn r_mark_regions(env: &mut SnowballEnv, context: &mut Context) -> bool {
             }
             env.next_char();
         }
-        context.i_p2 = env.cursor;
+        context.i_p2 = env.cursor as i32;
         break 'lab0;
     }
     env.cursor = v_1;
@@ -280,7 +280,7 @@ fn r_mark_regions(env: &mut SnowballEnv, context: &mut Context) -> bool {
 }
 
 fn r_R2(env: &mut SnowballEnv, context: &mut Context) -> bool {
-    if !(context.i_p2 <= env.cursor){
+    if !(context.i_p2 <= env.cursor as i32){
         return false;
     }
     return true;
@@ -345,11 +345,11 @@ pub fn stem(env: &mut SnowballEnv) -> bool {
     r_mark_regions(env, context);
     env.limit_backward = env.cursor;
     env.cursor = env.limit;
-    if env.cursor < context.i_pV {
+    if env.cursor < context.i_pV as usize {
         return false;
     }
     let v_3 = env.limit_backward;
-    env.limit_backward = context.i_pV;
+    env.limit_backward = context.i_pV as usize;
     let v_4 = env.limit - env.cursor;
     r_ending(env, context);
     env.cursor = env.limit - v_4;


### PR DESCRIPTION
I added a cargo feature to make serde optional, but default. Since the default feature set includes serde, it is opt out and should not break any crates that depend on this one.

There was problems building the Armenian algorithm, which I am not using, but I had to correct to get this crate to build. I don't know if the casts from usize to u32 are inappropriate or not, since they could overflow, but I don't think your cursors would require more than 32-bits. [Another fork](https://github.com/house-of-vanity/rust-stemmers/commits/master) removed the Armenian algorithm, probably because they were having problems too.