### PR TITLE
Fixed Context struct to have usize instead of i32

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/src/snowball/algorithms/armenian.rs
+++ b/src/snowball/algorithms/armenian.rs
@@ -214,8 +214,8 @@ static G_v: &'static [u8; 5] = &[209, 4, 128, 0, 18];
 
 #[derive(Clone)]
 struct Context {
-    i_p2: i32,
-    i_pV: i32,
+    i_p2: usize,
+    i_pV: usize,
 }
 
 fn r_mark_regions(env: &mut SnowballEnv, context: &mut Context) -> bool {


### PR DESCRIPTION
I kept getting an error as follows:

```text
error[E0308]: mismatched types
   --> src/snowball/algorithms/armenian.rs:352:26
    |
352 |     env.limit_backward = context.i_pV;
    |     ------------------   ^^^^^^^^^^^^ expected `usize`, found `i32`
    |     |
    |     expected due to the type of this binding

For more information about this error, try `rustc --explain E0308`.
```

This was easily fixed by changing the `Context` struct's fields to be `usize`. 

- [X] ran `cargo test`

Furthermore, I added a basic GH Actions workflow to run cargo test.